### PR TITLE
Allow conversion if md is already parsed, include top-level parameters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@ var url = require('url'),
     protagonist = require('protagonist'),
     UriTemplate = require('uritemplate');
 
-function apib2swagger(apib) {
+var apib2swagger = module.exports.convertParsed = function(apib) {
     //console.log(JSON.stringify(apib, null, 4));
     var swagger = {};
     swagger.swagger = '2.0';

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,7 +33,7 @@ var apib2swagger = module.exports.convertParsed = function(apib) {
             //console.log("-- " + resource.name + " " + resource.uriTemplate);
             var uriTemplate = UriTemplate.parse(resource.uriTemplate);
             var pathName = swaggerPathName(uriTemplate);
-            swagger.paths[pathName] = swaggerPath(resource.actions, group.name, uriTemplate);
+            swagger.paths[pathName] = swaggerPath(resource.parameters, resource.actions, group.name, uriTemplate);
         }
     }
     return swagger;
@@ -53,8 +53,10 @@ function swaggerPathName(uriTemplate) {
     return decodeURIComponent(uriTemplate.expand(params));
 }
 
-function swaggerPath(actions, tag, uriTemplate) {
+function swaggerPath(topParameters, actions, tag, uriTemplate) {
     path = {}
+    var parameters = swaggerParameters(topParameters, uriTemplate);
+    console.log('actions', actions);
     for (var k = 0; k < actions.length; k++) {
         var action = actions[k];
         //console.log("--- " + action.method);
@@ -62,10 +64,8 @@ function swaggerPath(actions, tag, uriTemplate) {
             'responses': swaggerResponses(action.examples),
             'summary': action.name,
             'description': action.description,
-            'tags': [tag]
-        }
-        if (action.parameters.length > 0) {
-            operation.parameters = swaggerParameters(action.parameters, uriTemplate);
+            'tags': [tag],
+            'parameters': parameters.concat(swaggerParameters(action.parameters, uriTemplate)),
         }
         //operation.produces = [];
         //for (var key in operation.responses) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -56,7 +56,6 @@ function swaggerPathName(uriTemplate) {
 function swaggerPath(topParameters, actions, tag, uriTemplate) {
     path = {}
     var parameters = swaggerParameters(topParameters, uriTemplate);
-    console.log('actions', actions);
     for (var k = 0; k < actions.length; k++) {
         var action = actions[k];
         //console.log("--- " + action.method);


### PR DESCRIPTION
The conversion was leaving out path-level parameters. Feel free to steal tests from https://github.com/lucybot/api-spec-converter