### PR TITLE
[Do not merge]Switch to pure JS parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var url = require('url'),
     http = require('http'),
-    protagonist = require('protagonist'),
+    drafter = require('drafter.js'),
     UriTemplate = require('uritemplate');
 
 var apib2swagger = module.exports.convertParsed = function(apib) {
@@ -277,20 +277,17 @@ function swaggerResponses(examples) {
 }
 
 exports.convert = function (data, callback) {
-    protagonist.parse(data, function (error, result) {
-        if (error) {
-            return callback(error, {});
-        }
-        //for (var i = 0; i < result.warnings.length; i++) {
-        //    var warn = result.warnings[i];
-        //    console.log(warn);
-        //}
-        try {
-            var swagger = apib2swagger(result.ast);
-        } catch (e) {
-            return callback(e, {});
-        }
-        return callback(null, {swagger: swagger});
-    });
+  try {
+    var result = drafter.parse(data, {type: 'ast'});
+    //for (var i = 0; i < result.warnings.length; i++) {
+    //    var warn = result.warnings[i];
+    //    console.log(warn);
+    //}
+    var swagger = apib2swagger(result.ast);
+    return callback(null, {swagger: swagger});
+  }
+  catch (error) {
+    return callback(error, {});
+  }
 };
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "name": "Keisuke Minami"
   },
   "dependencies": {
+    "drafter.js": "^2.0.0-pre.1",
     "nopt": ">=3.0.1",
-    "protagonist": ">=0.19.0 <1.0.0",
     "uritemplate": ">=0.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I trying to make [api-spec-converter](https://github.com/lucybot/api-spec-converter) pure JS to use browserify on it. Only dependence that is non-JS is `protagonist`, so I trying to switch to [drafter.js](https://www.npmjs.com/package/drafter.js) which is basically same code but run through `Emscripten` to convert from C++ to JS. 
It also should solve all problems with support of new version of `node.js`.

Right now it failing couple of test because they changed encoding of AST, see [this](https://github.com/apiaryio/drafter/blob/master/src/SerializeAST.cc#L447).
Can you help me to solve this problem?