### PR TITLE
Add response description when defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ function swaggerResponses(examples) {
             var response = example.responses[m];
             //console.log(response);
             var swaggerResponse = {
-                "description": http.STATUS_CODES[response.name],
+                "description": response.description || http.STATUS_CODES[response.name],
                 "headers": {},
                 "examples": {}
             };


### PR DESCRIPTION
Otherwise fallback to http status code default message, as previous behaviour.

See API Blueprint [1] response spec, and this thread [2] on StackOverflow for an example.

[1] <https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#example-3>

[2] <http://stackoverflow.com/a/23769985>