### PR TITLE
Move array examples one level up

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,10 +164,8 @@ var swaggerOperation = function (context, pathParams, uriTemplate, action, tag) 
 
                     // if we have example values in the body then insert them into the json schema
                     var body = JSON.parse(request.body);
-                    if(scheme['type'] === 'object'){
+                    if(['object', 'array'].includes(scheme['type'])){
                         scheme.example = body;
-                    } else if (scheme['type'] === 'array'){
-                        scheme.items.example = body;
                     }
                     if (scheme) schema.push(scheme);
                 } catch (e) {}
@@ -192,10 +190,8 @@ var swaggerOperation = function (context, pathParams, uriTemplate, action, tag) 
 
                                         // if we have example values in the body then insert them into the json schema
                                         var body = JSON.parse(request.body);
-                                        if(scheme['type'] === 'object'){
+                                        if(['object', 'array'].includes(scheme['type'])){
                                             scheme.example = body;
-                                        } else if (scheme['type'] === 'array'){
-                                            scheme.items.example = body;
                                         }
                                         schema.push(scheme);
                                     }


### PR DESCRIPTION
This prevents Swagger UI rendering `array of items` example as `array with array of items` as described here: https://github.com/swagger-api/swagger-ui/issues/4842