### PR TITLE
Add nullable type handing

### DIFF
--- a/src/mson_to_json_schema.js
+++ b/src/mson_to_json_schema.js
@@ -65,6 +65,9 @@ function convert(mson) {
                     case 'required':
                         schema.required.push(member.content.key.content);
                         break;
+                    case 'nullable':
+                    schema.properties[member.content.key.content].type = [schema.properties[member.content.key.content].type, 'null']
+                    break;
                 }
             });
         }


### PR DESCRIPTION
This adds the missing [`nullable`](https://apiblueprint.org/documentation/mson/specification.html#353-type-attribute) type handling in `typeAttributes`, which metioned in Issue #49 `nullable type is not probably handled`.